### PR TITLE
Combined PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@urql/introspection": "^1.2.1",
-    "daisyui": "^5.6.18",
+    "daisyui": "^5.7.9",
     "eslint": "9.39.1",
     "eslint-config-next": "16.2.10",
     "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tailwindcss/postcss": "^4.3.2",
     "@types/lodash": "^4.17.24",
     "@types/node": "^26.1.1",
-    "@types/react": "^19.2.17",
+    "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.3",
     "@urql/introspection": "^1.2.1",
     "daisyui": "^5.6.18",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dayjs": "^1.11.21",
     "iron-session": "^8.0.4",
     "lodash": "^4.18.1",
-    "mongoose": "^9.7.3",
+    "mongoose": "^9.9.0",
     "next": "16.2.11",
     "next-connect": "^1.0.0",
     "oauth-pkce": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-tailwindcss": "^4.2.0",
     "globals": "^17.7.0",
     "graphql": "^17.0.2",
-    "postcss": "^8.5.23",
+    "postcss": "^8.5.24",
     "prettier": "^3.8.3",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,10 +2126,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"daisyui@npm:^5.6.18":
-  version: 5.6.18
-  resolution: "daisyui@npm:5.6.18"
-  checksum: 10/ea05deb0d6e9ef13b1456f727d2f552f5874b720dd2465f383398217e367e7b698161f69c5419a193110dd607269f8b71d43e69c36a3c351f87829db5f0ae39f
+"daisyui@npm:^5.7.9":
+  version: 5.7.9
+  resolution: "daisyui@npm:5.7.9"
+  checksum: 10/690b1c5dfbeb7dd6f094bce9d97358a8adee3c323651d63480ec049a09cde6fb56072c1c8377b7c32d3b41fd28988ccd94d92adbfdac9e9761aea66f1058e775
   languageName: node
   linkType: hard
 
@@ -5155,7 +5155,7 @@ __metadata:
     "@urql/introspection": "npm:^1.2.1"
     axios: "npm:^1.18.1"
     clsx: "npm:^2.1.1"
-    daisyui: "npm:^5.6.18"
+    daisyui: "npm:^5.7.9"
     dayjs: "npm:^1.11.21"
     eslint: "npm:9.39.1"
     eslint-config-next: "npm:16.2.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,12 +1840,12 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10/94498bead66c51536df5b7bf1b0a0e581a5b7f86888be10481d06920c4bd9d976e003b13a3d19fddc733f21a09d162ff72f90e18b2c9d062b15121e973d0e13b
+  checksum: 10/b55a3c03239b8d2127c7cbb3408c9ad3a556a8c303bf3064df78bfb7c093160fc8f6e0a32e42a850a78eba12f29ccf6ef997690b9acf945d242c56c61c4aa977
   languageName: node
   linkType: hard
 
@@ -5099,14 +5099,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.23":
-  version: 8.5.23
-  resolution: "postcss@npm:8.5.23"
+"postcss@npm:^8.5.24":
+  version: 8.5.24
+  resolution: "postcss@npm:8.5.24"
   dependencies:
     nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/8387f421216696bf62a13e5a270e9fefdafc81e196903c0f8d7653f8bab315367cc2261b3c22cf197e492cb075f31bdfc07fd9c3be1cb165ff3cabe14c5a039a
+  checksum: 10/4e26169ed6fe8c2a32702d233b16368124d162a9399606381ed7a2f99ba6237360717aab339a0bd0f072280663413ff5115189b282085d1be74ffb2d25bdb562
   languageName: node
   linkType: hard
 
@@ -5170,7 +5170,7 @@ __metadata:
     next: "npm:16.2.11"
     next-connect: "npm:^1.0.0"
     oauth-pkce: "npm:^0.0.7"
-    postcss: "npm:^8.5.23"
+    postcss: "npm:^8.5.24"
     prettier: "npm:^3.8.3"
     react: "npm:^19"
     react-dom: "npm:^19.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,12 +821,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mongodb-js/saslprep@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "@mongodb-js/saslprep@npm:1.3.1"
+"@mongodb-js/saslprep@npm:^1.4.11":
+  version: 1.4.13
+  resolution: "@mongodb-js/saslprep@npm:1.4.13"
   dependencies:
     sparse-bitfield: "npm:^3.0.3"
-  checksum: 10/d66a447a29964058fdd3e89600cc06af4e2b5751e61fc059627b97b44608b5cb60039f74e0eb949d3e5ce61688690d1c63181a16dfccbf891fbe4250b316a63d
+  checksum: 10/6960fc0c2827c409fd27d451990f8c188f48ef7d5a06eb95b1aa0c709e743258d84abc2d015fe89959593d1621b03d56e6e99cb7a072bbd056604f7f6c4dc434
   languageName: node
   linkType: hard
 
@@ -4567,29 +4567,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb-connection-string-url@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "mongodb-connection-string-url@npm:7.0.0"
+"mongodb-connection-string-url@npm:^7.0.1":
+  version: 7.0.2
+  resolution: "mongodb-connection-string-url@npm:7.0.2"
   dependencies:
     "@types/whatwg-url": "npm:^13.0.0"
     whatwg-url: "npm:^14.1.0"
-  checksum: 10/478bb2a7d3cca8c0bffa6ccd9d74eacafd743c7eed27cb10744276da569378eadc48b9440d1a2e37aaabf00d938ccbb05bc454e63fa578ad607c7c0dfad02459
+  checksum: 10/19d01e7aa10c6a5baad900ac38c560299b3b6d897ad1cff6fe297c297434be73f77760b8894edb0270ae51ea82c6736e7308a882b8941138f4eb745de926f8b7
   languageName: node
   linkType: hard
 
-"mongodb@npm:~7.2":
-  version: 7.2.0
-  resolution: "mongodb@npm:7.2.0"
+"mongodb@npm:~7.5":
+  version: 7.5.0
+  resolution: "mongodb@npm:7.5.0"
   dependencies:
-    "@mongodb-js/saslprep": "npm:^1.3.0"
+    "@mongodb-js/saslprep": "npm:^1.4.11"
     bson: "npm:^7.2.0"
-    mongodb-connection-string-url: "npm:^7.0.0"
+    mongodb-connection-string-url: "npm:^7.0.1"
   peerDependencies:
     "@aws-sdk/credential-providers": ^3.806.0
     "@mongodb-js/zstd": ^7.0.0
     gcp-metadata: ^7.0.1
     kerberos: ^7.0.0
-    mongodb-client-encryption: ">=7.0.0 <7.1.0"
+    mongodb-client-encryption: ^7.2.0
     snappy: ^7.3.2
     socks: ^2.8.6
   peerDependenciesMeta:
@@ -4607,22 +4607,22 @@ __metadata:
       optional: true
     socks:
       optional: true
-  checksum: 10/9a1df6e0a1eb072efdfad3b9c452f0a225f966e890e027efbbca9f591a2a49fa6209faadfd9dfab8ee55362d0378c8f8d2dd2837873bc6aecff6ae422b359aad
+  checksum: 10/7cd86a9d5c7cd8a525082920101de54155470ad1dcd0575a2aefb8d3a7f9b68f7d82f851ddeb6e6f49d915e876d9e8fcc120a1f74c55de68c07257e19eb84423
   languageName: node
   linkType: hard
 
-"mongoose@npm:^9.7.3":
-  version: 9.7.3
-  resolution: "mongoose@npm:9.7.3"
+"mongoose@npm:^9.9.0":
+  version: 9.9.0
+  resolution: "mongoose@npm:9.9.0"
   dependencies:
     "@standard-schema/spec": "npm:^1.1.0"
     kareem: "npm:3.3.0"
-    mongodb: "npm:~7.2"
+    mongodb: "npm:~7.5"
     mpath: "npm:0.9.0"
     mquery: "npm:6.0.0"
     ms: "npm:2.1.3"
     sift: "npm:17.1.3"
-  checksum: 10/d79b8d695785e4187f8dad5c8e1487397e4fce948fa3992fc3638182b5c140348c54e5f98ddad844ca8eceae54b3975c2fca4da8f66278ea49f73deae0e059d7
+  checksum: 10/6fef56c941dd0ad7cda8957751c4b3ab8791a7841a086af3bd72f7458add112c314a9441b45c4e7446fc03f6323820f68c7db52fc2b09064b538571a5b3de92a
   languageName: node
   linkType: hard
 
@@ -5166,7 +5166,7 @@ __metadata:
     graphql: "npm:^17.0.2"
     iron-session: "npm:^8.0.4"
     lodash: "npm:^4.18.1"
-    mongoose: "npm:^9.7.3"
+    mongoose: "npm:^9.9.0"
     next: "npm:16.2.11"
     next-connect: "npm:^1.0.0"
     oauth-pkce: "npm:^0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,12 +1197,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^19.2.17":
-  version: 19.2.17
-  resolution: "@types/react@npm:19.2.17"
+"@types/react@npm:^19.2.18":
+  version: 19.2.18
+  resolution: "@types/react@npm:19.2.18"
   dependencies:
     csstype: "npm:^3.2.2"
-  checksum: 10/8debb092bd0bb9c99176a31824c7587c27c775a6526b60060e7b9e8dc2af53aee2ffadc7a1e3845953792437db5699d34a9054e198c9d4e54a74728ff47c6725
+  checksum: 10/c718ec5c5272ef5c1c77fcdd07f567c77197b593583539459b4bdaea89ca55ad7c814b7eb2151dccfa459b2c384b599a45e7e35550b789883d66b363d30c94d8
   languageName: node
   linkType: hard
 
@@ -5148,7 +5148,7 @@ __metadata:
     "@tailwindcss/postcss": "npm:^4.3.2"
     "@types/lodash": "npm:^4.17.24"
     "@types/node": "npm:^26.1.1"
-    "@types/react": "npm:^19.2.17"
+    "@types/react": "npm:^19.2.18"
     "@types/react-dom": "npm:^19.2.3"
     "@uidotdev/usehooks": "npm:^2.4.1"
     "@urql/exchange-graphcache": "npm:^9.0.1"


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #802 Bump brace-expansion from 1.1.16 to 1.1.18 in the npm_and_yarn group across 1 directory
- Closes #799 Bump daisyui from 5.6.18 to 5.7.9
- Closes #798 Bump @types/react from 19.2.17 to 19.2.18
- Closes #797 Bump mongoose from 9.7.3 to 9.9.0

⚠️ The following PRs were left out due to merge conflicts:
- #803 Bump github/codeql-action from 4.37.3 to 4.37.5
- #800 Bump prettier from 3.8.3 to 3.9.6
- #795 Bump postcss from 8.5.23 to 8.5.25

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action