### PR TITLE
Combined PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.5
+      uses: github/codeql-action/init@v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -64,7 +64,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.5
+      uses: github/codeql-action/autobuild@v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -77,6 +77,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.5
+      uses: github/codeql-action/analyze@v4.37.6
       with:
         category: "/language:${{matrix.language}}"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-tailwindcss": "^4.2.0",
-    "globals": "^17.7.0",
+    "globals": "^17.9.0",
     "graphql": "^17.0.2",
     "postcss": "^8.5.25",
     "prettier": "^3.9.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",
     "@iconify-json/mdi": "^1.2.3",
-    "@iconify-json/simple-icons": "^1.2.87",
+    "@iconify-json/simple-icons": "^1.2.93",
     "@iconify/tailwind4": "^1.2.3",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/lodash": "^4.17.24",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-tailwindcss": "^4.2.0",
     "globals": "^17.7.0",
     "graphql": "^17.0.2",
-    "postcss": "^8.5.25",
+    "postcss": "^8.5.26",
     "prettier": "^3.9.6",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@iconify-json/simple-icons": "^1.2.87",
     "@iconify/tailwind4": "^1.2.3",
     "@tailwindcss/postcss": "^4.3.2",
-    "@types/lodash": "^4.17.24",
+    "@types/lodash": "^4.17.25",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@uidotdev/usehooks": "^2.4.1",
     "@urql/exchange-graphcache": "^9.0.1",
-    "axios": "^1.18.1",
+    "axios": "^1.19.0",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.21",
     "iron-session": "^8.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,10 +1172,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.17.24":
-  version: 4.17.24
-  resolution: "@types/lodash@npm:4.17.24"
-  checksum: 10/0f2082565f60f9787eefc046edc38458054512be5a8b3584ef0bad5fd9e85d0ab55ec5a1fbfae1ed6ba015cf1f9e837d5fb4da1f99fc60b8f74b2a46146fb00f
+"@types/lodash@npm:^4.17.25":
+  version: 4.17.25
+  resolution: "@types/lodash@npm:4.17.25"
+  checksum: 10/f786e05664439cc8d327fd97c62c060d81b3c4ed52127d01fbc926139e1a669c1554bf3cd0dbb43f8fcc7d9b5c6c23c543cc36de8dc815c9f289ea852b26ebd6
   languageName: node
   linkType: hard
 
@@ -5146,7 +5146,7 @@ __metadata:
     "@iconify-json/simple-icons": "npm:^1.2.87"
     "@iconify/tailwind4": "npm:^1.2.3"
     "@tailwindcss/postcss": "npm:^4.3.2"
-    "@types/lodash": "npm:^4.17.24"
+    "@types/lodash": "npm:^4.17.25"
     "@types/node": "npm:^26.1.1"
     "@types/react": "npm:^19.2.18"
     "@types/react-dom": "npm:^19.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,15 +1790,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "axios@npm:1.18.1"
+"axios@npm:^1.19.0":
+  version: 1.19.0
+  resolution: "axios@npm:1.19.0"
   dependencies:
     follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
+    form-data: "npm:^4.0.6"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/c4cdced3ee0a9bf7dcae189fbc74a124aa079d4f04dbd995e602d39c1419476e8d021f87ee39ac8d8398e5a55e6d0b986238b3645f0d9177ac80de87c2a73f18
+  checksum: 10/d27e263b003f2dc1e6d0e2ab062dbc7c2b15668c25723e1e2072f139505c1fbd1f8cffef77d5ec05bb8e3cefa6fc5325c6446e747669fd95d85519529fa0db0b
   languageName: node
   linkType: hard
 
@@ -3227,7 +3227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.5":
+"form-data@npm:^4.0.6":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:
@@ -5153,7 +5153,7 @@ __metadata:
     "@uidotdev/usehooks": "npm:^2.4.1"
     "@urql/exchange-graphcache": "npm:^9.0.1"
     "@urql/introspection": "npm:^1.2.1"
-    axios: "npm:^1.18.1"
+    axios: "npm:^1.19.0"
     clsx: "npm:^2.1.1"
     daisyui: "npm:^5.7.9"
     dayjs: "npm:^1.11.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4647,30 +4647,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.6":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.11, nanoid@npm:^3.3.12, nanoid@npm:^3.3.17, nanoid@npm:^3.3.6":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.12":
-  version: 3.3.13
-  resolution: "nanoid@npm:3.3.13"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/e9d4c96f0fd42effa696103395c3d71f1123125f7ad926c7a2222b1d1691df4ddfa35e833549bc46bcc807fcfac776ff9fd737226ee37a0561f61747fa061eb9
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 
@@ -5099,14 +5081,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.25":
-  version: 8.5.25
-  resolution: "postcss@npm:8.5.25"
+"postcss@npm:^8.5.26":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
   dependencies:
-    nanoid: "npm:^3.3.16"
+    nanoid: "npm:^3.3.17"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/68aaeb314a1b2407e11e926acc0462b01b3e911d3d9e755d06adc5b2ececdefe8432dc3c3c93eacc07138952e17997d4674529061b8e3a338a7ac4c1accfdf98
+  checksum: 10/842a624f822f77cb37264cc24f0cf97c0a69dd8d6f7b4a6d76b5a8dc95355899dd044f33a2d4e890da858293de570fce18dff453f3b629ff14cac67a3591895a
   languageName: node
   linkType: hard
 
@@ -5170,7 +5152,7 @@ __metadata:
     next: "npm:16.2.11"
     next-connect: "npm:^1.0.0"
     oauth-pkce: "npm:^0.0.7"
-    postcss: "npm:^8.5.25"
+    postcss: "npm:^8.5.26"
     prettier: "npm:^3.9.6"
     react: "npm:^19"
     react-dom: "npm:^19.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,12 +488,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iconify-json/simple-icons@npm:^1.2.87":
-  version: 1.2.87
-  resolution: "@iconify-json/simple-icons@npm:1.2.87"
+"@iconify-json/simple-icons@npm:^1.2.93":
+  version: 1.2.93
+  resolution: "@iconify-json/simple-icons@npm:1.2.93"
   dependencies:
     "@iconify/types": "npm:*"
-  checksum: 10/98df6efa95b54916e592f8bd048c3d7ad7940fd38ca3310fe4915eda96af4669cc3630ef66ece95a10d762836ed11a7cd81524d07c47dc6d075a150b9a38e5cc
+  checksum: 10/e7749ba617bf74badb8690a3a9d5f3bd459ab6065fd3cdb8499d879e40a36a99764bc5da4ed748eb7df03f365eaf6af2ab9cb4c093f0643bf1e71b84ae43890c
   languageName: node
   linkType: hard
 
@@ -5143,7 +5143,7 @@ __metadata:
     "@eslint/eslintrc": "npm:^3.3.6"
     "@eslint/js": "npm:^10.0.1"
     "@iconify-json/mdi": "npm:^1.2.3"
-    "@iconify-json/simple-icons": "npm:^1.2.87"
+    "@iconify-json/simple-icons": "npm:^1.2.93"
     "@iconify/tailwind4": "npm:^1.2.3"
     "@tailwindcss/postcss": "npm:^4.3.2"
     "@types/lodash": "npm:^4.17.24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,10 +3413,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^17.7.0":
-  version: 17.7.0
-  resolution: "globals@npm:17.7.0"
-  checksum: 10/79304ccc4d2ca167ea15bdb25da346aa34ce3847b18fbd6c3cad182e152505305db3c9722fd5e292c62f6db97a8fa06e0c110a1e7703d7325498e5351d08cab4
+"globals@npm:^17.9.0":
+  version: 17.9.0
+  resolution: "globals@npm:17.9.0"
+  checksum: 10/8619386d449e8cbb81e242eced8bca0a42e5c3633a3a35996b8b1618beb17ff9fb33bfe703d60d83d4b7f6f8a996dede4faf02f9e966e50ff895e0cf6122ae15
   languageName: node
   linkType: hard
 
@@ -5162,7 +5162,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-prettier: "npm:^5.5.6"
     eslint-plugin-tailwindcss: "npm:^4.2.0"
-    globals: "npm:^17.7.0"
+    globals: "npm:^17.9.0"
     graphql: "npm:^17.0.2"
     iron-session: "npm:^8.0.4"
     lodash: "npm:^4.18.1"


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #811 Bump nanoid from 3.3.11 to 3.3.18 in the npm_and_yarn group across 1 directory
- Closes #809 Bump @types/lodash from 4.17.24 to 4.17.25
- Closes #808 Bump axios from 1.18.1 to 1.19.0
- Closes #807 Bump @iconify-json/simple-icons from 1.2.87 to 1.2.93
- Closes #806 Bump github/codeql-action from 4.37.5 to 4.37.6
- Closes #805 Bump globals from 17.7.0 to 17.9.0

⚠️ The following PRs were left out due to merge conflicts:
- #810 Bump @tailwindcss/postcss from 4.3.2 to 4.3.3

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action